### PR TITLE
Add quiz feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,17 @@ decideNextSubScene(currentScene) {
 This is a very simple logic at present, but it gives us the flexibility to write more complex logic if we need.
 
 So, a little more technically, how is it enabling this clarity? The magic is in [StoryScene](https://github.com/kodikos/houndville/blob/master/src/shared/StoryScene.js). This class acts as a tracker for which sub scene is currently on display by storing it in its' state. It checks which is currently set and only displays that sub scene. It also sets up the event on the scene wrapper to trap the click actions and call the `decideNextSubScene()` for you. 
+
+## Quizzes
+
+What's the fun of a game if it isn't interactive? 
+
+The Quiz works by acting like a decision tree for the next sub-scene to move to. It sets out the question, then when an answer is given, it moves it to a sub-scene that contains the result.
+
+It introduces a slightly tricky scenario in hiding the mechanics. Ideally, you want each answer to have an onclick that will perform the action of moving to the next sub-scene. But, in trying to hide it, we lose the context for working with the sub-scene.
+
+I have gone for minimizing the interaction by passing an event to the [Quiz](https://github.com/kodikos/houndville/blob/master/src/shared/Quiz.js) class. I use something close to magic in React to transform the child Choice components to add a reference to that event by creating my own onClick prop. React doesn't let you manipulate a child component, they are _immutable_. However, you can easily clone it and set up new props for it (here's a great post about working with [children in react](https://frontarm.com/james-k-nelson/passing-data-props-children/)). This is handled in the rendering of the Quiz component. Back in my scene, I just need to invoke it to change the sub-scene when that event is called.
+
+Something extra that I have to do is disable event bubbling. This is because I listen for clicks anywhere in the scene, and the buttons on the quiz are in the scene. I add the `e.stopPropagation()` to prevent the event being fired for the scene as well.
+
+The quiz mechanism can potentially be used for introducing alternative story narratives and a choice of sub-scene. This is where the flexibility of the `decideNextSubScene()` comes in handy to manage this.

--- a/src/ValleyScene/index.js
+++ b/src/ValleyScene/index.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styled from 'styled-components';
 
 import StoryScene from '../shared/StoryScene';
 import { TextBox, Backdrop } from '../shared/Common';
+import { Quiz, Question, Choice } from '../shared/Quiz';
 import BackgroundImage from './background.png';
 
 const Background = styled(Backdrop)`
@@ -15,8 +16,19 @@ export default class ValleyScene extends StoryScene {
         switch(currentScene) {
             case 'init': return 'tantalizing';
             case 'tantalizing' : return 'head-down';
+            case 'head-down': return 'quiz-gate-name';
+            case 'quiz-gate-name' : return 'quiz-gate-name';
+            case 'quiz-drawbridge' : return 'over-the-bridge';
+            case 'quiz-moat' :
+            case 'quiz-portcullis' :
+                return 'quiz-gate-name';
+            case 'over-the-bridge' : return 'over-the-bridge';
             default: return 'init';
         }
+    }
+
+    handleQuizAnswer = (next, isCorrect) => {
+        this.changeSubScene(next);
     }
 
     render() {
@@ -41,6 +53,43 @@ export default class ValleyScene extends StoryScene {
                     <TextBox>
                         You head down towards a bridge. As you get closer you
                         can see a special kind of gate
+                    </TextBox>
+                </SubScene>
+
+                <SubScene name="quiz-gate-name">
+                    <Quiz onAnswer={this.handleQuizAnswer}>
+                        <Question>What is the name of a gate that drops down 
+                            over water?</Question>
+                        <Choice next="quiz-drawbridge">Drawbridge</Choice>
+                        <Choice next="quiz-moat">Moat</Choice>
+                        <Choice next="quiz-portcullis">Portcullis</Choice>
+                    </Quiz>
+                </SubScene>
+
+                <SubScene name="quiz-drawbridge">
+                    <TextBox>
+                        Correct! It's called this because it has to be drawn up by
+                        chains to close it
+                    </TextBox>
+                </SubScene>
+
+                <SubScene name="quiz-moat">
+                    <TextBox>
+                        Sorry, that's wrong. The moat is the name for the water
+                        surrounding a fortification
+                    </TextBox>
+                </SubScene>
+
+                <SubScene name="quiz-portcullis">
+                    <TextBox>
+                        Sorry, that's wrong. A portcullis is a gate that comes down
+                        from above, usually from the ceiling of a gatehouse entrance
+                    </TextBox>
+                </SubScene>
+
+                <SubScene name="over-the-bridge">
+                    <TextBox>
+                        You go over the bridge and stand before the drawbridge...
                     </TextBox>
                 </SubScene>
             </SceneWrapper>

--- a/src/shared/Quiz.js
+++ b/src/shared/Quiz.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+
+import { TextBox } from '../shared/Common';
+
+const QuizBox = styled(TextBox)`
+    background: rgba(142, 153, 231, 0.8);
+    color: white;
+`;
+
+export const Question = styled.span``;
+
+export const Quiz = (props) => 
+    <QuizBox>
+        {React.Children.map(props.children, (child) => {
+            if (child.props.next) {
+                return React.cloneElement(child, { onClick: (e) => {
+                    e.stopPropagation();
+                    props.onAnswer(child.props.next, child.props.correct);
+                }});
+            }
+            return child;
+        })}
+    </QuizBox>;
+
+export const Choice = styled.button`
+    background: none;
+    border: 3px solid transparent;
+    font-size: inherit;
+    color: inherit;
+    padding: 10px;
+    width: 99%;
+    margin: 10px auto;
+    &:hover {
+        border: 3px solid white;
+    }
+`;

--- a/src/shared/StoryScene.js
+++ b/src/shared/StoryScene.js
@@ -21,16 +21,21 @@ export default class StoryScene extends Component {
 
     SceneWrapper = (props) => {
         return (
-            <CommonSceneWrapper  onClick={this.changeSubScene}>
+            <CommonSceneWrapper onClick={this.changeSubSceneEvent}>
                 {props.children}
             </CommonSceneWrapper>
         );
     }
 
-    changeSubScene = () => {
+    changeSubScene = (sceneName) => {
         this.setState({
-            subscene: this.decideNextSubScene(this.state.subscene)
+            subscene: sceneName
         });
+    }
+
+    changeSubSceneEvent = () => {
+        const nextScene = this.decideNextSubScene(this.state.subscene);
+        this.changeSubScene(nextScene);
     }
 
     decideNextSubScene(currentScene) {


### PR DESCRIPTION
This adds a reusable component for making sub-scenes that involve a quiz question that decides the next sub-scene to move to.
To do this I had to:
- Create quiz rendering components
- Manipulate child components to create a convenient onclick callback to process the result of the question
- Rejig the sub-scene handling a little in StoryScene to support switching the current sub-scene via a direct call, rather than just by state (saves 2 state updates at once)
- Prevent event bubbling so the scene doesn't try to move the state twice